### PR TITLE
Use whitelist for gh-reports instead of blacklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ This will perform a full check, going through all of your organizations and thei
 #### Optional Flags
 _Skip the GitHub scan and test only the upload_
 ```
-./augit gitlic --upload-only
+./gitlic-check gitlic --upload-only
 ```
 _Skip the upload step and perform only the GitHub scan_
 ```
-./augit gitlic --no-upload
+./gitlic-check gitlic --no-upload
 ```
 
 ## Configuration
@@ -65,6 +65,7 @@ GitLic requires a config file, located at `config/options.json`:
   "github":
     "pat": "", // string
     "ignoredOrgs": [], // []string (optional)
+    "includedOrgs": [], // []string (optional)
     "rmInvitesAfter": 336, // int (optional) // in hours (ex: 2 weeks = 336)
   "drive": // (optional)
     "outputDir": "", // string // id for output directory
@@ -74,6 +75,8 @@ GitLic requires a config file, located at `config/options.json`:
 
 #### GitHub
 You'll need to generate a personal access token [in your GitHub settings](https://github.com/settings/tokens). If you want to include private repositories in your reports, be sure to select the entire repo scope in the token settings. If you want to ignore any orgs in the process of scanning, put their names in the optional array. Finally, if you want to automatically remove invitations after a certain amount of time, include that option and the time frame in hours.
+
+The gh_report command populates the Augit database with GitHub users and instead of using the `ignoredOrgs` setting it uses `includedOrgs` as a whitelist.
 
 >Note: Must be an owner of the org to pull data on private repos, members, and two-factor authentication
 

--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,7 @@ type Config struct {
 type GhConfig struct {
 	Token          string   `json:"pat"`
 	IgnoredOrgs    []string `json:"ignoredOrgs,omitempty"`
+	IncludedOrgs   []string `json:"includedOrgs,omitempty"`
 	RmInvitesAfter int      `json:"rmInvitesAfter,omitempty"` // in hours
 }
 

--- a/swgithub/swgithub.go
+++ b/swgithub/swgithub.go
@@ -12,17 +12,17 @@ import (
 	"golang.org/x/oauth2"
 )
 
-// getIgnoredMap will turn the array of ignored orgs from the config file into a map that is easy to check against as we iterate over organizations returned from the GitHub API
-func getIgnoredMap(a []string) map[string]bool {
-	ignoredOrgs := make(map[string]bool)
+// getIncludedMap will turn the array of included orgs from the config file into a map that is easy to check against as we iterate over organizations returned from the GitHub API
+func getIncludedMap(a []string) map[string]bool {
+	includedOrgs := make(map[string]bool)
 	for _, org := range a {
-		ignoredOrgs[org] = true
+		includedOrgs[org] = true
 	}
-	return ignoredOrgs
+	return includedOrgs
 }
 
 func GetSWOrgs(ctx context.Context, ghClient *github.Client, cf config.Config) ([]*github.Organization, error) {
-	ignoredOrgs := getIgnoredMap(cf.Github.IgnoredOrgs)
+	includedOrgs := getIncludedMap(cf.Github.IncludedOrgs)
 	orgs := []*github.Organization{}
 	lo := &github.ListOptions{PerPage: 100}
 	for {
@@ -42,11 +42,11 @@ func GetSWOrgs(ctx context.Context, ghClient *github.Client, cf config.Config) (
 	}
 	validOrgs := []*github.Organization{}
 	for _, org := range orgs {
-		if ignoredOrgs == nil {
+		if includedOrgs == nil {
 			validOrgs = orgs
 			break
 		}
-		if !ignoredOrgs[*org.Login] {
+		if includedOrgs[*org.Login] {
 			validOrgs = append(validOrgs, org)
 		} else {
 			log.Printf("Ignored %s\n", *org.Login)


### PR DESCRIPTION
The config files need to be updated before this is merged, but I wanted to get the PR up while I was thinking about it.