### PR TITLE
Fix sa bug

### DIFF
--- a/augit/models/github_owner_accessor.go
+++ b/augit/models/github_owner_accessor.go
@@ -6,6 +6,7 @@ import (
 
 type GithubOwnerAccessor interface {
 	Create(*GithubOwner) error
+	ExistsByGithubID(string) (bool, error)
 	ExistsByGithubIDInOrg(string, string) (bool, error)
 	List() ([]*GithubOwner, error)
 	Delete(string) error
@@ -21,6 +22,10 @@ func NewGithubOwnerDB(tx *pop.Connection) *GithubOwnerDB {
 
 func (ghodb *GithubOwnerDB) Create(inUser *GithubOwner) error {
 	return ghodb.tx.Create(inUser)
+}
+
+func (ghodb *GithubOwnerDB) ExistsByGithubID(ghID string) (bool, error) {
+	return ghodb.tx.Where("LOWER(github_id = LOWER(?)", ghID).Exists(&GithubOwner{})
 }
 
 func (ghodb *GithubOwnerDB) ExistsByGithubIDInOrg(ghID, org string) (bool, error) {

--- a/augit/models/github_owner_accessor.go
+++ b/augit/models/github_owner_accessor.go
@@ -25,7 +25,7 @@ func (ghodb *GithubOwnerDB) Create(inUser *GithubOwner) error {
 }
 
 func (ghodb *GithubOwnerDB) ExistsByGithubID(ghID string) (bool, error) {
-	return ghodb.tx.Where("LOWER(github_id = LOWER(?)", ghID).Exists(&GithubOwner{})
+	return ghodb.tx.Where("LOWER(github_id) = LOWER(?)", ghID).Exists(&GithubOwner{})
 }
 
 func (ghodb *GithubOwnerDB) ExistsByGithubIDInOrg(ghID, org string) (bool, error) {

--- a/augit/models/github_user_accessor.go
+++ b/augit/models/github_user_accessor.go
@@ -13,6 +13,7 @@ type GithubUserAccessor interface {
 	ReplaceGHRow(*GithubUser) error
 	Find(string) (*GithubUser, error)
 	FindByID(uuid.UUID) (*GithubUser, error)
+	FindByGithubID(string) (*GithubUser, error)
 	ExistsByGithubID(string) (bool, error)
 	ListGHUsers() ([]*GithubUser, error)
 	Delete(string) error
@@ -80,6 +81,11 @@ func (ghudb *GithubUserDB) Find(username string) (*GithubUser, error) {
 func (ghudb *GithubUserDB) FindByID(id uuid.UUID) (*GithubUser, error) {
 	foundUser := &GithubUser{}
 	return foundUser, ghudb.tx.Where("id = ?", id).First(foundUser)
+}
+
+func (ghudb *GithubUserDB) FindByGithubID(ghID string) (*GithubUser, error) {
+	foundUser := &GithubUser{}
+	return foundUser, ghudb.tx.Where("LOWER(github_id) = LOWER(?)", ghID).First(foundUser)
 }
 
 //

--- a/augit/models/service_account_accessor.go
+++ b/augit/models/service_account_accessor.go
@@ -1,12 +1,15 @@
 package models
 
-import "github.com/gobuffalo/pop"
+import (
+	"github.com/gobuffalo/pop"
+)
 
 type ServiceAccountAccessor interface {
 	Create(*ServiceAccount) error
 	Exists(string) (bool, error)
 	FindByGithubID(string) (*ServiceAccount, error)
 	List() ([]*ServiceAccount, error)
+	Delete(string) error
 }
 
 type ServiceAccountDB struct {
@@ -39,4 +42,13 @@ func (sadb *ServiceAccountDB) List() ([]*ServiceAccount, error) {
 
 func (sadb *ServiceAccountDB) Exists(ghID string) (bool, error) {
 	return sadb.tx.Where("LOWER(github_id) = LOWER(?)", ghID).Exists(&ServiceAccount{})
+}
+
+func (sadb *ServiceAccountDB) Delete(ghID string) error {
+	sa := &ServiceAccount{}
+	err := sadb.tx.Where("LOWER(github_id) = LOWER(?)", ghID).First(sa)
+	if err != nil {
+		return err
+	}
+	return sadb.tx.Destroy(sa)
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -84,6 +84,7 @@ func augitHandlers(tx *pop.Connection) *mux.Router {
 	augit.Handle("/users", sp.RequireAccount(http.HandlerFunc(ao.HTTPHandler(handlers.ShowAccounts(ghudb, sadb))))).Methods("GET")
 	augit.Handle("/user", sp.RequireAccount(http.HandlerFunc(ao.HTTPHandler(handlers.AddUser(ghudb))))).Methods("POST")
 	augit.Handle("/service_account", sp.RequireAccount(http.HandlerFunc(ao.HTTPHandler(handlers.AddServiceAccount(ghudb, ghodb, sadb))))).Methods("POST")
+	augit.Handle("/service_account", sp.RequireAccount(http.HandlerFunc(ao.HTTPHandler(handlers.RemoveServiceAccount(ghudb, sadb, ghodb))))).Methods("DELETE")
 	augit.Handle("/check_admin", sp.RequireAccount(http.HandlerFunc(ao.HTTPHandler(handlers.CheckAdmin(ghudb))))).Methods("GET")
 	augit.Handle("/admin/{email}", sp.RequireAccount(http.HandlerFunc(ao.HTTPHandler(handlers.AddAdmin(ghudb))))).Methods("POST")
 	augit.Handle("/admin/{email}", sp.RequireAccount(http.HandlerFunc(ao.HTTPHandler(handlers.RemoveAdmin(ghudb))))).Methods("DELETE")


### PR DESCRIPTION
Ideally, this will check that the GitHub ID submitted for a service account is not already registered to a SolarWinds user. If it detects that it is or fails to verify that it's not, it will return an error.

I also added an endpoint for removing a service account. This should require that the user either is the one who initially submitted the service account or is an owner of a SolarWinds org.