### PR TITLE
Add error log key for GitHub org calls; improve error reporting around AO submission

### DIFF
--- a/cmd/gh_report.go
+++ b/cmd/gh_report.go
@@ -65,6 +65,7 @@ func persistUsers(ghudb models.GithubUserAccessor, ghodb models.GithubOwnerAcces
 	ghClient := github.NewClient(oauth2.NewClient(ctx, oauth2.StaticTokenSource(&oauth2.Token{AccessToken: cf.Github.Token})))
 	orgs, err := swgithub.GetSWOrgs(ctx, ghClient, cf)
 	if err != nil {
+		log.WithError(err).Fatal("50011: Could not retrieve GitHub orgs")
 		return err
 	}
 	allMembers := []*github.User{}

--- a/cmd/gh_report.go
+++ b/cmd/gh_report.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -41,8 +42,9 @@ var ghReportCmd = &cobra.Command{
 			log.Fatalln(err)
 		}
 		log.Info(generateSuccessString("gh-report"))
-		_, err = mService.Create(ao.NewMeasurementsBatch([]ao.Measurement{measurement}, nil))
-		if err != nil {
+		resp, err := mService.Create(ao.NewMeasurementsBatch([]ao.Measurement{measurement}, nil))
+		log.Info(fmt.Sprintf("Response creating AO measurement %d", resp.StatusCode))
+		if err != nil || resp.StatusCode >= 400 {
 			log.Fatalln(err)
 		}
 	},

--- a/cmd/offboard.go
+++ b/cmd/offboard.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"time"
 
@@ -54,8 +55,9 @@ var offboardCmd = &cobra.Command{
 		aldb := models.NewAuditLogDB(db)
 		offboard(aldb)
 		log.Info(generateSuccessString("offboard"))
-		_, err := mService.Create(ao.NewMeasurementsBatch([]ao.Measurement{measurement}, nil))
-		if err != nil {
+		resp, err := mService.Create(ao.NewMeasurementsBatch([]ao.Measurement{measurement}, nil))
+		log.Info(fmt.Sprintf("Response creating AO measurement %d", resp.StatusCode))
+		if err != nil || resp.StatusCode >= 400 {
 			log.Fatalln(err)
 		}
 	},

--- a/cmd/offboard.go
+++ b/cmd/offboard.go
@@ -68,7 +68,7 @@ func offboard(aldb models.AuditLogAccessor) {
 
 	orgs, err := swgithub.GetSWOrgs(context.Background(), client, cf)
 	if err != nil {
-		log.WithError(err).Fatal("50003: Could not retrieve GitHub orgs")
+		log.WithError(err).Fatal("50011: Could not retrieve GitHub orgs")
 	}
 
 	for _, org := range orgs {

--- a/cmd/populate.go
+++ b/cmd/populate.go
@@ -33,7 +33,7 @@ var populateCmd = &cobra.Command{
 		}
 		log.Info(generateSuccessString("populate"))
 		resp, err := mService.Create(ao.NewMeasurementsBatch([]ao.Measurement{measurement}, nil))
-		log.Info(fmt.Sprintf("Response creating measurement %d", resp.StatusCode))
+		log.Info(fmt.Sprintf("Response creating AO measurement %d", resp.StatusCode))
 		if err != nil || resp.StatusCode >= 400 {
 			log.Fatalln(err)
 		}

--- a/cmd/populate.go
+++ b/cmd/populate.go
@@ -32,8 +32,9 @@ var populateCmd = &cobra.Command{
 			log.Fatalln(err)
 		}
 		log.Info(generateSuccessString("populate"))
-		_, err = mService.Create(ao.NewMeasurementsBatch([]ao.Measurement{measurement}, nil))
-		if err != nil {
+		resp, err := mService.Create(ao.NewMeasurementsBatch([]ao.Measurement{measurement}, nil))
+		log.Info(fmt.Sprintf("Response creating measurement %d", resp.StatusCode))
+		if err != nil || resp.StatusCode >= 400 {
 			log.Fatalln(err)
 		}
 	},


### PR DESCRIPTION
In the original changes around this there were some issues around error handling because of how the AO library returns errors, which was incorrectly leading to jobs reporting as errors without any actual error being shown. We are now logging the status code of all AO responses from measurement submission, as the response body often does not contain useful information (https://docs.appoptics.com/api/#http-status-codes)

This also adds an error log key for GitHub errors so we can have Loggly alerts keyed off of it.